### PR TITLE
m4: rectify return code of aes-xts duplicate key functionality check

### DIFF
--- a/data/m4/libcrypto.m4
+++ b/data/m4/libcrypto.m4
@@ -28,7 +28,8 @@ AC_DEFUN([AX_LIBCRYPTO_CHECK_XTS_DUPLICATE_KEYS_SUPPORT],
     LIBS="$LIBS $ac_cv_libcrypto_LIBADD"
     AC_RUN_IFELSE(
       [AC_LANG_PROGRAM(
-        [[#include <openssl/err.h>
+        [[#include <stdlib.h>
+#include <openssl/err.h>
 #include <openssl/evp.h>]],
         [[unsigned char key[ 16 ] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 int result = 0;
@@ -49,7 +50,7 @@ EVP_CIPHER_CTX_cleanup( &ctx );
 EVP_CIPHER_CTX_free( ctx );
 #endif
 
-return( result == 1 ); ]] )],
+return( result == 1 ? EXIT_SUCCESS : EXIT_FAILURE ); ]] )],
       [ac_cv_openssl_xts_duplicate_keys=yes],
       [ac_cv_openssl_xts_duplicate_keys=no])
     LIBS="$ac_cv_libcrypto_backup_LIBS"


### PR DESCRIPTION
Building libcaes shows for me:

```
checking if `EVP_CipherInit_ex' can be used with duplicate keys... no
```

Upon review, one sees in `m4/libcrypto.m4`:

```
result = EVP_CipherInit_ex(ctx, EVP_aes_128_xts(), NULL, key, key, 0);
...
return( result == 1 ); ]] )],
```

`EVP_CipherInit_ex` returns 1 on success, but `main` has different semantics.